### PR TITLE
Update: string_ops.rs - Add implementation of ScalaLikeStringOps.strip_margin for str and comment to explain how to use

### DIFF
--- a/src/string_ops.rs
+++ b/src/string_ops.rs
@@ -2,6 +2,7 @@ pub trait ScalaLikeStringOps {
   /// Returns a string slice with leading whitespace and | removed
   /// It removes the leading whitespace chars then remove the subsequent '|' if found.
   /// # Examples
+  /// ## For `String`,
   /// ```
   /// let s = format!("a=123
   ///                 |b=456
@@ -16,10 +17,34 @@ pub trait ScalaLikeStringOps {
   /// c=789
   /// "
   /// ```
+  /// ***
+  /// ## For `str`,
+  /// ```
+  /// let s = "a=123
+  ///         |b=456
+  ///         |c=789
+  ///         |".strip_margin();
+  /// ```
+  /// returns
+  /// ```
+  /// "a=123
+  /// b=456
+  /// c=789
+  /// "
+  /// ```
   fn strip_margin(&self) -> String;
 }
 
 impl ScalaLikeStringOps for String {
+  fn strip_margin(&self) -> String {
+    self.lines()
+      .map(|line| line.trim_start().trim_start_matches('|'))
+      .collect::<Vec<&str>>()
+      .join("\n")
+  }
+}
+
+impl ScalaLikeStringOps for str {
   fn strip_margin(&self) -> String {
     self.lines()
       .map(|line| line.trim_start().trim_start_matches('|'))


### PR DESCRIPTION
Update: `string_ops.rs` - Add implementation of `ScalaLikeStringOps.strip_margin` for `str` and comment to explain how to use