### PR TITLE
Update: `string_ops.rs` - A single implementation for both `String` and `str` (more precisely, for any `AsRef<str>`)

### DIFF
--- a/src/string_ops.rs
+++ b/src/string_ops.rs
@@ -35,18 +35,10 @@ pub trait ScalaLikeStringOps {
   fn strip_margin(&self) -> String;
 }
 
-impl ScalaLikeStringOps for String {
+impl<A: AsRef<str>> ScalaLikeStringOps for A {
   fn strip_margin(&self) -> String {
-    self.lines()
-      .map(|line| line.trim_start().trim_start_matches('|'))
-      .collect::<Vec<&str>>()
-      .join("\n")
-  }
-}
-
-impl ScalaLikeStringOps for str {
-  fn strip_margin(&self) -> String {
-    self.lines()
+    self.as_ref()
+      .lines()
       .map(|line| line.trim_start().trim_start_matches('|'))
       .collect::<Vec<&str>>()
       .join("\n")


### PR DESCRIPTION
Update: `string_ops.rs` - A single implementation for both `String` and `str` (more precisely, for any `AsRef<str>`)