### PR TITLE
Add: `freezing.rs` - An example of frozen mutability by shadowing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod variable_bindings {
   pub mod mutability;
   pub mod scope_and_shadowing;
   pub mod declare_first;
+  pub mod freezing;
 }
 
 use custom_types::constants;
@@ -30,6 +31,7 @@ use variable_bindings::bindings;
 use variable_bindings::mutability;
 use variable_bindings::scope_and_shadowing;
 use variable_bindings::declare_first;
+use variable_bindings::freezing;
 
 fn main() {
   println!("===== hello world =====");
@@ -87,4 +89,6 @@ fn main() {
   println!("\n===== variable bindings - declare first =====");
   declare_first::declare_first();
 
+  println!("\n===== variable bindings - freezing (mutability frozen by shadowing) =====");
+  freezing::freezing();
 }

--- a/src/variable_bindings/freezing.rs
+++ b/src/variable_bindings/freezing.rs
@@ -1,0 +1,17 @@
+pub fn freezing() -> () {
+  let mut some_number = 1i32;
+
+  println!("[0] outer some_number: {}", some_number);
+  {
+    // outer some_number is shadowed by this inner immutable some_number
+    let some_number = some_number;
+
+    println!("[1] inner some_number: {}", some_number);
+
+    // Compile-time error
+    // cannot assign twice to immutable variable
+    // some_number = 999;
+  }
+  some_number = 3;
+  println!("[2] outer some_number: {}", some_number);
+}


### PR DESCRIPTION
Add: `freezing.rs` - An example of frozen mutability by shadowing - inner immutable variable can shadow outer mutable variable with the same name - so mutability is frozen in the scope where the immutable variable with the same name as the mutable one is declared